### PR TITLE
support username and password authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: go
+go:
+    - "1.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: go
 go:
-    - "1.10"
+  - "1.10"
+
+install:
+  - go get -t ./...

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-VERSION = 1.0.0
+VERSION = 2.0.0
 PKG = ./cmd/itags
 PLATFORMS = darwin/386 darwin/amd64 linux/386 linux/amd64 linux/arm windows/386 windows/amd64
 
 LDFLAGS = -ldflags="-X main.Version=$(VERSION)"
+
+default: test
 
 all: clean test dist
 
@@ -21,6 +23,6 @@ version:
 dist:
 	@gox -verbose $(LDFLAGS) \
 		-osarch="$(PLATFORMS)" \
-        -output "dist/{{.Dir}}_$(VERSION)_{{.OS}}_{{.Arch}}" $(PKG)
+        -output "dist/{{.Dir}}-$(VERSION)-{{.OS}}-{{.Arch}}" $(PKG)
 
-.PHONY: all clean test install version dist
+.PHONY: default all clean test install version dist

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ takes ~1.5 seconds to retrieve 3358 tags.
 
 ## Install
 
-Download a [binary](https://github.com/mgk/itags/releases) or:
+Download a [released binary](https://github.com/mgk/itags/releases).
+
+Or to use the latest development version:
 
 ```bash
 go get github.com/mgk/itags/cmd/itags
@@ -36,18 +38,23 @@ itags redis
 
 # Get tags for multiple repos
 itags hello-world mgkio/figlet hello-world
+
+# Get tags for my-private-repo
+itags -u my-username -p secret my-username/my-private-repo
+
+# Get tags for private repo using DOCKER_TOKEN
+export DOCKER_TOKEN=my-token
+itags my-username/my-private-repo
 ```
 
 Go pacakge API: see tests for examples.
 
-## Notes
+## Notes on private repos
+If username and password are supplied they are used to get a docker
+[JWT](https://jwt.io/) which is sent with each request to the docker registry.
+Otherwise if the environment variable `DOCKER_TOKEN` is set it is used instead.
 
-Private repositories are supported, but currently require that you set the
-environment variable `DOCKER_TOKEN` to a valid JWT. This is a stop-gap measure.
-`itags` will add support for acquiring the JWT via the
-`https://hub.docker.com/v2/users/login/` endpoint.
-
-For the ambitious you can get a JWT with `curl` and `jq`:
+You can get a JWT with `curl` and [jq](https://stedolan.github.io/jq/):
 
 ```bash
 export DOCKER_TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "MY_USERNAME", "password": "MY_PASSWORD"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
@@ -75,7 +82,6 @@ Many thanks to Jerry Baker for the [docker KB article showing how it's done](htt
 the max page size returned by docker is 100.*
 
 ### Todos
-- prompt for login and generate token
 - CI build
 - go doc for package
 - negative test cases

--- a/cmd/itags/itags.go
+++ b/cmd/itags/itags.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -12,42 +13,57 @@ import (
 	docopt "github.com/docopt/docopt-go"
 )
 
-// Version Overridden by -ldflags
+// Version - overridden by -ldflags
 var Version = "dev"
 
 func main() {
 	usage := `itags - list the image tags for one or more docker repositories
 
-  Usage:
-    itags [options] REPOSITORY...
-    itags -h
+Usage:
+  itags [options] REPOSITORY...
+  itags ---help
 
-  Options:
-    -h --help      Show this screen.
-    --version      Show version.
-    -p --prefix    Prefix each tag with repository name. This only applies when
-                   a single repository is specified. When multiple repositories
-                   are specified tags are always prefixed with their repository
-                   name.
-    --workers=<n>  Max # of Number of HTTP requests to run in parallel [default: 20].`
+Options:
+  -h --help                            Show this screen
+  --version                            Show version
+  -u <username> --username=<username>  Username
+  -p <password> --password=<password>  Password
+  --prefix                             Prefix each tag with repository name. This only applies when
+                                       a single repository is specified. When multiple repositories
+                                       are specified tags are always prefixed with their repository
+                                       name.
+  --workers=<n>                        Max # of Number of HTTP requests to run in parallel [default: 20]`
 
 	args, _ := docopt.ParseArgs(usage, nil, Version)
 
 	httpClient := &http.Client{Timeout: 15 * time.Second}
 	numWorkers, _ := args.Int("--workers")
+	username, _ := args.String("--username")
+	password, _ := args.String("--password")
 	prefix, _ := args.Bool("--prefix")
 	repositories := args["REPOSITORY"].([]string)
 
+	var jwt = os.Getenv("DOCKER_TOKEN")
+	if username != "" {
+		creds := itags.Credentials{Username: username, Password: password}
+		var err error
+		jwt, err = itags.Authenticate(httpClient, creds)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
 	var tags []string
 	if len(repositories) == 1 {
-		tags = itags.GetTags(repositories[0], httpClient, numWorkers)
+		tags = itags.GetTags(repositories[0], httpClient, jwt, numWorkers)
 		if prefix {
 			for i, t := range tags {
 				tags[i] = repositories[0] + ":" + t
 			}
 		}
 	} else {
-		tags = itags.GetTagsForRepositories(repositories, httpClient, numWorkers)
+		tags = itags.GetTagsForRepositories(repositories, httpClient, jwt, numWorkers)
 	}
 	sort.Strings(tags)
 	fmt.Println(strings.Join(tags, "\n"))

--- a/itags.go
+++ b/itags.go
@@ -1,18 +1,21 @@
 package itags
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 )
 
 const (
-	RepositoryBaseURL string = "https://hub.docker.com/v2/repositories"
-	PageSize          int    = 100
+	authURL           string = "https://hub.docker.com/v2/users/login/"
+	repositoryBaseURL string = "https://hub.docker.com/v2/repositories"
+	pageSize          int    = 100
 )
 
 // Job - tag request to be made
@@ -34,6 +37,16 @@ type JobResult struct {
 type Tag struct {
 	Name        string    `json:"name"`
 	LastUpdated time.Time `json:"last_updated"`
+}
+
+// Credentials for docker registry
+type Credentials struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type loginResponse struct {
+	Token string `json:"token"`
 }
 
 // TagSlice tag slice sortable by name
@@ -60,13 +73,13 @@ func sleepMillis(millis int) {
 }
 
 // GetTags get tag names for a repostiory
-func GetTags(repository string, httpClient *http.Client, numWorkers int) []string {
-	return GetTagsForRepository(repository, httpClient, numWorkers)
+func GetTags(repository string, httpClient *http.Client, jwt string, numWorkers int) []string {
+	return GetTagsForRepository(repository, httpClient, jwt, numWorkers)
 }
 
 // GetTagsForRepository get tag names for a repository
-func GetTagsForRepository(repository string, httpClient *http.Client, numWorkers int) []string {
-	tags := GetTagDetails([]string{repository}, httpClient, numWorkers)[repository]
+func GetTagsForRepository(repository string, httpClient *http.Client, jwt string, numWorkers int) []string {
+	tags := GetTagDetails([]string{repository}, httpClient, jwt, numWorkers)[repository]
 	// log.Printf("tags --> %v\n", tags)
 	answer := make([]string, len(tags))
 	for i, tag := range tags {
@@ -77,8 +90,8 @@ func GetTagsForRepository(repository string, httpClient *http.Client, numWorkers
 
 // GetTagsForRepositories get tag names for a list of repositories
 // Each tag is prefixed by its repository name
-func GetTagsForRepositories(repositories []string, httpClient *http.Client, numWorkers int) []string {
-	tagsByRepo := GetTagDetails(repositories, httpClient, numWorkers)
+func GetTagsForRepositories(repositories []string, httpClient *http.Client, jwt string, numWorkers int) []string {
+	tagsByRepo := GetTagDetails(repositories, httpClient, jwt, numWorkers)
 	answer := make([]string, 0, 100)
 	for repo, tags := range tagsByRepo {
 		for _, tag := range tags {
@@ -89,7 +102,7 @@ func GetTagsForRepositories(repositories []string, httpClient *http.Client, numW
 }
 
 // GetTagDetails get tags for a list of repostiories
-func GetTagDetails(repositories []string, httpClient *http.Client, numWorkers int) map[string][]Tag {
+func GetTagDetails(repositories []string, httpClient *http.Client, jwt string, numWorkers int) map[string][]Tag {
 	if numWorkers < 1 {
 		numWorkers = 1
 	}
@@ -98,7 +111,7 @@ func GetTagDetails(repositories []string, httpClient *http.Client, numWorkers in
 	jobs := make(chan Job, len(repositories))
 	firstResults := make(chan JobResult, len(repositories))
 	for i := 1; i <= numWorkers; i++ {
-		go worker(httpClient, jobs, firstResults)
+		go worker(httpClient, jwt, jobs, firstResults)
 	}
 
 	for _, r := range repositories {
@@ -113,7 +126,7 @@ func GetTagDetails(repositories []string, httpClient *http.Client, numWorkers in
 			fmt.Printf("%v", r.Error)
 		}
 		tags[r.Repository] = append(tags[r.Repository], r.Tags...)
-		pages := (r.Count - 1) / PageSize
+		pages := (r.Count - 1) / pageSize
 		for i := 0; i < pages; i++ {
 			batches = append(batches, Job{Repository: r.Repository, Page: i + 2})
 		}
@@ -122,7 +135,7 @@ func GetTagDetails(repositories []string, httpClient *http.Client, numWorkers in
 	results := make(chan JobResult, min(len(batches), 1000))
 	jobs = make(chan Job, min(len(batches), 1000))
 	for i := 1; i <= numWorkers; i++ {
-		go worker(httpClient, jobs, results)
+		go worker(httpClient, jwt, jobs, results)
 	}
 
 	for _, b := range batches {
@@ -141,18 +154,18 @@ func GetTagDetails(repositories []string, httpClient *http.Client, numWorkers in
 	return tags
 }
 
-func worker(httpClient *http.Client, jobs <-chan Job, results chan<- JobResult) {
+func worker(httpClient *http.Client, jwt string, jobs <-chan Job, results chan<- JobResult) {
 	for job := range jobs {
 		// results <- fakeTagBatch(job)
-		results <- tagBatch(httpClient, job)
+		results <- tagBatch(httpClient, jwt, job)
 	}
 }
 
 func fakeTagBatch(job Job) JobResult {
 	sleepMillis(rand.Intn(1000))
 
-	tags := make([]Tag, PageSize)
-	for i := 0; i < PageSize; i++ {
+	tags := make([]Tag, pageSize)
+	for i := 0; i < pageSize; i++ {
 		tags[i] = Tag{Name: fmt.Sprintf("tag-%d", i+1)}
 	}
 	var count int
@@ -167,15 +180,37 @@ func fakeTagBatch(job Job) JobResult {
 	}
 }
 
-var jwt = os.Getenv("DOCKER_TOKEN")
+// Authenticate and get docker token
+func Authenticate(httpClient *http.Client, credentials Credentials) (string, error) {
 
-func tagBatch(httpClient *http.Client, job Job) JobResult {
+	body, _ := json.Marshal(credentials)
+
+	req, err := http.NewRequest("POST", authURL, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 400 {
+		body, _ = ioutil.ReadAll(res.Body)
+		return "", errors.New("login error: " + string(body))
+	}
+	loginResponse := new(loginResponse)
+	err = json.NewDecoder(res.Body).Decode(loginResponse)
+	return loginResponse.Token, err
+}
+
+func tagBatch(httpClient *http.Client, jwt string, job Job) JobResult {
 	repository := job.Repository
 	if !strings.Contains(repository, "/") {
 		repository = "library/" + repository
 	}
 	url := fmt.Sprintf("%s/%s/tags/?page=%d&page_size=%d",
-		RepositoryBaseURL, repository, job.Page, PageSize)
+		repositoryBaseURL, repository, job.Page, pageSize)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/itags_test.go
+++ b/itags_test.go
@@ -35,7 +35,7 @@ func TestGetTagsSmallOfficialRepository(t *testing.T) {
 	repo := "hello-world"
 	tape, http := mockHTTP("hello-world")
 	defer tape.Stop()
-	tags := GetTags(repo, http, NumWorkers)
+	tags := GetTags(repo, http, "", NumWorkers)
 	sort.Strings(tags)
 
 	assertEqual(t, "hello world",
@@ -53,7 +53,7 @@ func TestGetTagsSmallUnofficialRepository(t *testing.T) {
 	tape, http := mockHTTP("figlet")
 	defer tape.Stop()
 
-	tags := GetTags("mgkio/figlet", http, NumWorkers)
+	tags := GetTags("mgkio/figlet", http, "", NumWorkers)
 	sort.Strings(tags)
 
 	assertEqual(t, "figlet", []string{"1", "latest"}, tags)
@@ -64,7 +64,7 @@ func TestGetTagsForRepository(t *testing.T) {
 	tape, http := mockHTTP("hello-world")
 	defer tape.Stop()
 
-	tags := GetTagsForRepository("hello-world", http, NumWorkers)
+	tags := GetTagsForRepository("hello-world", http, "", NumWorkers)
 	sort.Strings(tags)
 
 	assertEqual(t, "hello world",
@@ -82,7 +82,7 @@ func TestGetTagsMultiplePages(t *testing.T) {
 	tape, http := mockHTTP("redis")
 	defer tape.Stop()
 
-	tags := GetTags("redis", http, NumWorkers)
+	tags := GetTags("redis", http, "", NumWorkers)
 	sort.Strings(tags)
 
 	assertEqual(t, "redis", []string{
@@ -116,7 +116,7 @@ func TestGetTagsForRepositories(t *testing.T) {
 	tape, http := mockHTTP("hello-and-figlet")
 	defer tape.Stop()
 
-	tags := GetTagsForRepositories([]string{"hello-world", "mgkio/figlet"}, http, NumWorkers)
+	tags := GetTagsForRepositories([]string{"hello-world", "mgkio/figlet"}, http, "", NumWorkers)
 	sort.Strings(tags)
 	assertEqual(t, "hello world and figlet", []string{
 		"hello-world:latest",
@@ -151,7 +151,7 @@ func TestGetDetailsLarge(t *testing.T) {
 	for repo := range counts {
 		repos = append(repos, repo)
 	}
-	tags := GetTagDetails(repos, http, NumWorkers)
+	tags := GetTagDetails(repos, http, "", NumWorkers)
 	for repo, count := range counts {
 		assertEqual(t, repo, len(tags[repo]), count)
 	}


### PR DESCRIPTION
- `-u` and `-p` are used if present otherwise `DOCKER_TOKEN`
env var is used, readme has details

- start version 2 as above change is not backwards compatible
in that `-p` used to behave differently

- setup travis to run tests